### PR TITLE
fix: respect configured header level range

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -520,7 +520,7 @@ export default class HeaderEnhancerPlugin extends Plugin {
 						line,
 						config.startLevel
 					);
-					if (headerLevel <= 0) {
+					if (headerLevel <= 0 || realHeaderLevel > config.endLevel) {
 						continue;
 					}
 					insertNumber = getNextNumber(insertNumber, headerLevel);


### PR DESCRIPTION
Fixes #52.

Headers deeper than the configured end level are now skipped during auto-numbering. For example, when manual numbering is set to H1-H3, H4-H6 headings no longer receive numbering.