### PR TITLE
fix: handle indented code fences

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -95,6 +95,19 @@ export function isHeader(text: string): boolean {
 	return /^#{1,6} .*/.test(text.trim());
 }
 
+export function updateCodeBlockState(line: string, isCodeBlock: boolean): boolean {
+	const trimmedLine = line.trimStart();
+	if (!trimmedLine.startsWith("```")) {
+		return isCodeBlock;
+	}
+
+	isCodeBlock = !isCodeBlock;
+	if (trimmedLine.slice(3).includes("```")) {
+		isCodeBlock = !isCodeBlock;
+	}
+	return isCodeBlock;
+}
+
 export interface HeaderLevelAnalysis {
 	minLevel: number;      // 文档中最高层级（数字最小的#，如H2=2）
 	maxLevel: number;      // 文档中最低层级（数字最大的#，如H5=5）
@@ -111,12 +124,7 @@ export function analyzeHeaderLevels(content: string): HeaderLevelAnalysis {
 	
 	for (const line of lines) {
 		// 处理代码块（复用现有逻辑）
-		if (line.startsWith("```")) {
-			isCodeBlock = !isCodeBlock;
-			if (line.slice(3).includes("```")) {
-				isCodeBlock = !isCodeBlock;
-			}
-		}
+		isCodeBlock = updateCodeBlockState(line, isCodeBlock);
 		
 		if (isCodeBlock) continue;
 		

--- a/src/dialogs.ts
+++ b/src/dialogs.ts
@@ -1,7 +1,7 @@
 import { App, Modal, Setting, Notice, TFile } from "obsidian";
 import HeaderEnhancerPlugin from "./main";
 import { I18n } from "./i18n";
-import { removeHeaderNumber, isHeader, getNextNumber } from "./core";
+import { removeHeaderNumber, isHeader, getNextNumber, updateCodeBlockState } from "./core";
 import { getAutoNumberingConfig } from "./config";
 
 export class AutoNumberingRemovalDialog extends Modal {
@@ -232,10 +232,7 @@ export class AutoNumberingRemovalDialog extends Modal {
                 const line = lines[i];
                 
                 // Track code blocks
-                if (line.startsWith("```")) {
-                    isInCodeBlock = !isInCodeBlock;
-                    continue;
-                }
+                isInCodeBlock = updateCodeBlockState(line, isInCodeBlock);
                 
                 // Skip processing headers inside code blocks
                 if (isInCodeBlock) {
@@ -532,12 +529,7 @@ export class AutoNumberingActivationDialog extends Modal {
                 const line = lines[i];
                 
                 // Track code blocks
-                if (line.startsWith("```")) {
-                    isInCodeBlock = !isInCodeBlock;
-                    if (line.slice(3).contains("```")) {
-                        isInCodeBlock = !isInCodeBlock;
-                    }
-                }
+                isInCodeBlock = updateCodeBlockState(line, isInCodeBlock);
                 
                 // Skip processing headers inside code blocks
                 if (isInCodeBlock) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
 	removeHeaderNumber,
 	isHeader,
 	analyzeHeaderLevels,
+	updateCodeBlockState,
 } from "./core";
 import { getAutoNumberingYaml, setAutoNumberingYaml } from "./utils";
 import {
@@ -504,12 +505,7 @@ export default class HeaderEnhancerPlugin extends Plugin {
 				const line = editor.getLine(i);
 				docCharCount += line.length;
 
-				if (line.startsWith("```")) {
-					isCodeBlock = !isCodeBlock;
-					if (line.slice(3).contains("```")) {
-						isCodeBlock = !isCodeBlock;
-					}
-				}
+				isCodeBlock = updateCodeBlockState(line, isCodeBlock);
 
 				if (isCodeBlock) {
 					continue;


### PR DESCRIPTION
Fixes #49.

This updates code fence detection to handle fences with leading whitespace or tabs, so indented fenced code blocks no longer break header numbering for the rest of the document.

Validation:
- npm run build
- Verified against the issue #49 attachment: headings after the indented code fence are detected again, and hash-prefixed comments inside code blocks are skipped.