### PR TITLE
fix: renumber headings with space separators

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
+		"test": "node --test tests/*.test.mjs",
 		"build": "node esbuild.config.mjs production",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},

--- a/src/core.ts
+++ b/src/core.ts
@@ -24,6 +24,8 @@ export function getNextNumber(
 	return nextNums;
 }
 
+const HEADER_NUMBER_PATTERN = /^(\d+(?:[.,\-\/]\d+)*)\s+/;
+
 export function isNeedInsertNumber(text: string, splitor: string): boolean {
 	// '## header' true
 	// '## 1.1 splitor header' false
@@ -36,10 +38,10 @@ export function isNeedInsertNumber(text: string, splitor: string): boolean {
 	if (splitor == " ") {
 		// Check if content starts with a number pattern (e.g., "1.1 text" or "1 text")
 		// Should return false if numbering exists, true if it doesn't
-		return !/^\d+(?:\.\d+)*\s+/.test(contentAfterHash);
+		return !HEADER_NUMBER_PATTERN.test(contentAfterHash);
 	} else {
 		// For other splitors, check if the splitor exists in the content
-		return !contentAfterHash.contains(splitor);
+		return !contentAfterHash.includes(splitor);
 	}
 }
 
@@ -57,7 +59,7 @@ export function isNeedUpdateNumber(
 
 	if (splitor == " ") {
 		// Extract the number pattern at the start (e.g., "1.1" from "1.1 header text")
-		const numMatch = contentAfterHash.match(/^(\d+(?:\.\d+)*)\s+/);
+		const numMatch = contentAfterHash.match(HEADER_NUMBER_PATTERN);
 		if (!numMatch) return true; // No number found, needs update
 		cntNumsStr = numMatch[1];
 	} else {
@@ -80,15 +82,27 @@ export function removeHeaderNumber(text: string, splitor: string): string {
 
 	if (splitor == " ") {
 		// Remove number pattern at the start (e.g., "1.1 " from "1.1 header text")
-		const header = contentAfterHash.replace(/^\d+(?:\.\d+)*\s+/, '');
+		const header = contentAfterHash.replace(HEADER_NUMBER_PATTERN, '');
 		return sharp + " " + header;
 	} else {
 		// For other splitors, remove everything before and including the first splitor
-		if (!contentAfterHash.contains(splitor)) return text;
+		if (!contentAfterHash.includes(splitor)) return text;
 		const parts = contentAfterHash.split(splitor);
 		const header = parts.slice(1).join(splitor).trim();
 		return sharp + " " + header;
 	}
+}
+
+export function setHeaderNumber(
+	text: string,
+	number: string,
+	splitor: string
+): string {
+	const unnumberedText = removeHeaderNumber(text, splitor);
+	const match = unnumberedText.match(/^(#{1,6})\s+(.*)/);
+	if (!match) return text;
+
+	return `${match[1]} ${number}${splitor}${match[2]}`;
 }
 
 export function isHeader(text: string): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import {
 	isNeedUpdateNumber,
 	isNeedInsertNumber,
 	removeHeaderNumber,
+	setHeaderNumber,
 	isHeader,
 	analyzeHeaderLevels,
 	updateCodeBlockState,
@@ -533,12 +534,11 @@ export default class HeaderEnhancerPlugin extends Plugin {
 					) {
 						// Add numbering to header - extract original title
 						originalHeading = line.substring(realHeaderLevel + 1).trim();
-						
-						newLine = "#".repeat(realHeaderLevel) +
-							" " +
-							insertNumberStr +
-							this.settings.autoNumberingHeaderSeparator +
-							line.substring(realHeaderLevel + 1);
+						newLine = setHeaderNumber(
+							line,
+							insertNumberStr,
+							this.settings.autoNumberingHeaderSeparator
+						);
 					} else if (
 						isNeedUpdateNumber(
 							insertNumberStr,
@@ -546,21 +546,17 @@ export default class HeaderEnhancerPlugin extends Plugin {
 							this.settings.autoNumberingHeaderSeparator
 						)
 					) {
-						// Update existing numbering - extract title after separator
-						const textAfterSeparator = line.split(this.settings.autoNumberingHeaderSeparator)[1];
-						originalHeading = textAfterSeparator ? textAfterSeparator.trim() : null;
-						
-						const originNumberLength = line
-							.split(
-								this.settings.autoNumberingHeaderSeparator
-							)[0]
-							.split(" ")[1].length;
-						newLine = "#".repeat(realHeaderLevel) +
-							" " +
-							insertNumberStr +
-							line.substring(
-								realHeaderLevel + originNumberLength + 1
-							);
+						// Update existing numbering while preserving the plain heading text.
+						const unnumberedLine = removeHeaderNumber(
+							line,
+							this.settings.autoNumberingHeaderSeparator
+						);
+						originalHeading = unnumberedLine.substring(realHeaderLevel + 1).trim();
+						newLine = setHeaderNumber(
+							line,
+							insertNumberStr,
+							this.settings.autoNumberingHeaderSeparator
+						);
 					}
 
 					// Record header changes for backlink updates

--- a/tests/core.test.mjs
+++ b/tests/core.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { build } from "esbuild";
+
+const result = await build({
+	entryPoints: ["src/core.ts"],
+	bundle: true,
+	format: "esm",
+	platform: "node",
+	write: false,
+	logLevel: "silent",
+});
+const source = result.outputFiles[0].text;
+const core = await import(
+	`data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+);
+
+test("updates an existing heading number with a space separator", () => {
+	assert.equal(core.setHeaderNumber("# 2 Header Two", "3", " "), "# 3 Header Two");
+});
+
+test("updates an existing heading number with a tab separator", () => {
+	assert.equal(
+		core.setHeaderNumber("## 1.2\tSub-header two", "1.3", "\t"),
+		"## 1.3\tSub-header two"
+	);
+});
+
+test("supports every configured number separator with a space header separator", () => {
+	for (const separator of [".", ",", "-", "/"]) {
+		const currentNumber = `1${separator}2`;
+		const nextNumber = `1${separator}3`;
+		const heading = `## ${currentNumber} Sub-header two`;
+
+		assert.equal(core.isNeedInsertNumber(heading, " "), false);
+		assert.equal(core.isNeedUpdateNumber(nextNumber, heading, " "), true);
+		assert.equal(
+			core.setHeaderNumber(heading, nextNumber, " "),
+			`## ${nextNumber} Sub-header two`
+		);
+	}
+});
+
+test("preserves heading text and its internal whitespace while renumbering", () => {
+	assert.equal(
+		core.setHeaderNumber("## 1.2 A  heading with spaces", "1.3", " "),
+		"## 1.3 A  heading with spaces"
+	);
+});
+
+test("adds a number to an unnumbered heading", () => {
+	assert.equal(core.setHeaderNumber("## New heading", "1.2", " "), "## 1.2 New heading");
+});
+
+test("renumbers headings after inserting a heading in the middle", () => {
+	const headings = [
+		["# 1 Header One", 1],
+		["## 1.1 Sub-header one", 2],
+		["## New sub-header", 2],
+		["## 1.2 Sub-header two", 2],
+		["# 2 Header Two", 1],
+	];
+	let numbers = [0];
+
+	const result = headings.map(([heading, level]) => {
+		numbers = core.getNextNumber(numbers, level);
+		return core.setHeaderNumber(heading, numbers.join("."), " ");
+	});
+
+	assert.deepEqual(result, [
+		"# 1 Header One",
+		"## 1.1 Sub-header one",
+		"## 1.2 New sub-header",
+		"## 1.3 Sub-header two",
+		"# 2 Header Two",
+	]);
+});


### PR DESCRIPTION
## What changed
- centralize heading number replacement so existing numbering is removed safely before rebuilding the heading
- support `.`, `,`, `-`, and `/` number separators when the heading separator is a space
- add regression tests for space/tab separators and inserting a heading between existing headings

## Why
With a space heading separator, updating an existing heading tried to derive the old number length from a split result that could be undefined. The renumbering pass then stopped before updating later headings.

## Verification
- `npm test`
- `npm run build`
- `git diff --check`

Closes #51