### PR TITLE
feat: refresh numbering after leaving headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ header-auto-numbering: ["state on", "start-level h2", "end-level h6", "start-at 
 
 **Daily Usage**
 - ✅ Press `Enter` on header line to auto-add/update numbering
-- ✅ After manually changing header level, move cursor to line and press `Enter` to refresh
+- ✅ After editing a header or changing its level, move the cursor to another line to refresh numbering
 - ✅ Click ribbon icon to quickly toggle current document numbering
 
 **Bulk Operations**
@@ -153,7 +153,6 @@ header-auto-numbering: ["state on", "start-level h2", "end-level h6", "start-at 
 - 🎯 Project docs: Start from H2, preserve H1 as document title
 
 ## 🐛 Known Issues
-- Manual refresh needed when changing header levels (press `Enter`)
 - Default separator uses tab character (`\t`)
 
 Report bugs at [GitHub Issues](https://github.com/HoBeedzc/obsidian-header-enhancer-plugin/issues)

--- a/README.zh.md
+++ b/README.zh.md
@@ -139,7 +139,7 @@ header-auto-numbering: ["state on", "start-level h2", "end-level h6", "start-at 
 
 **日常使用**
 - ✅ 在标题行按 `Enter` 自动添加/更新编号
-- ✅ 手动修改标题级别后，光标移到该行按 `Enter` 刷新
+- ✅ 编辑标题或修改标题级别后，将光标移到其他行即可刷新编号
 - ✅ 点击功能区图标快速切换当前文档的编号状态
 
 **批量操作**
@@ -153,7 +153,6 @@ header-auto-numbering: ["state on", "start-level h2", "end-level h6", "start-at 
 - 🎯 项目文档：从 H2 开始编号，保留 H1 作为文档标题
 
 ## 🐛 已知问题
-- 更改标题级别需手动刷新（按 `Enter`）
 - 默认分隔符使用制表符（`\t`）
 
 在 [GitHub Issues](https://github.com/HoBeedzc/obsidian-header-enhancer-plugin/issues) 报告问题

--- a/src/editor/editor-handlers.ts
+++ b/src/editor/editor-handlers.ts
@@ -1,10 +1,17 @@
-import { EditorView, keymap } from "@codemirror/view";
+import { EditorView, keymap, ViewPlugin, ViewUpdate } from "@codemirror/view";
 import { Prec, Extension } from "@codemirror/state";
-import { MarkdownView } from "obsidian";
+import { editorInfoField, MarkdownView } from "obsidian";
 import { isHeader } from "../core";
 import { getAutoNumberingConfig } from "../config";
 import { AutoNumberingMode } from "../setting";
 import type HeaderEnhancerPlugin from "../main";
+import {
+	HEADER_ENHANCER_USER_EVENT,
+	HeadingChangeTracker,
+	isTrackedDocumentChange,
+} from "./heading-change";
+
+const HEADING_REFRESH_DEBOUNCE_MS = 200;
 
 /**
  * 处理编辑器相关的操作，包括按键处理和 CodeMirror 集成
@@ -90,6 +97,13 @@ export class EditorHandlers {
 		];
 	}
 
+	registerHeadingRefreshHandler(): Extension {
+		const plugin = this.plugin;
+		return ViewPlugin.define(
+			(view) => new HeadingLeaveRefreshHandler(view, plugin)
+		);
+	}
+
 	/**
 	 * 处理 Enter 键按下事件
 	 */
@@ -139,7 +153,7 @@ export class EditorHandlers {
 		view.dispatch({
 			changes,
 			selection: { anchor: currentLine.from + textBeforeCursor.length + 1 },
-			userEvent: "HeaderEnhancer.changeAutoNumbering",
+			userEvent: HEADER_ENHANCER_USER_EVENT,
 		});
 
 		// 在操作完成后更新标题编号
@@ -186,9 +200,112 @@ export class EditorHandlers {
 		view.dispatch({
 			changes,
 			selection: { anchor: pos - 1 },
-			userEvent: "HeaderEnhancer.changeAutoNumbering",
+			userEvent: "delete.backward",
 		});
 
 		return true;
+	}
+}
+
+class HeadingLeaveRefreshHandler {
+	private readonly tracker = new HeadingChangeTracker();
+	private refreshTimer: number | null = null;
+	private refreshRunning = false;
+	private refreshQueued = false;
+	private destroyed = false;
+
+	constructor(
+		private readonly view: EditorView,
+		private readonly plugin: HeaderEnhancerPlugin
+	) {}
+
+	update(update: ViewUpdate): void {
+		let trackedChange = false;
+		for (const transaction of update.transactions) {
+			if (isTrackedDocumentChange(transaction)) {
+				trackedChange = true;
+				this.tracker.applyChanges(
+					transaction.startState.doc,
+					transaction.state.doc,
+					transaction.changes
+				);
+			} else if (transaction.docChanged) {
+				this.tracker.clear();
+				this.pauseScheduledRefresh();
+			}
+		}
+
+		if (
+			trackedChange &&
+			this.tracker.hasSelectionOnDirtyLine(update.state.doc, update.state.selection)
+		) {
+			this.pauseScheduledRefresh();
+		}
+
+		const editorLostFocus = update.focusChanged && !update.view.hasFocus;
+		if (
+			(editorLostFocus && this.tracker.consume()) ||
+			this.tracker.consumeIfSelectionLeft(update.state.doc, update.state.selection)
+		) {
+			this.scheduleRefresh();
+		}
+	}
+
+	destroy(): void {
+		this.destroyed = true;
+		if (this.refreshTimer !== null) {
+			window.clearTimeout(this.refreshTimer);
+		}
+	}
+
+	private scheduleRefresh(): void {
+		this.pauseScheduledRefresh();
+
+		this.refreshTimer = window.setTimeout(() => {
+			this.refreshTimer = null;
+			void this.refresh();
+		}, HEADING_REFRESH_DEBOUNCE_MS);
+	}
+
+	private pauseScheduledRefresh(): void {
+		if (this.refreshTimer !== null) {
+			window.clearTimeout(this.refreshTimer);
+			this.refreshTimer = null;
+		}
+	}
+
+	private async refresh(): Promise<void> {
+		if (this.destroyed) {
+			return;
+		}
+
+		if (this.refreshRunning) {
+			this.refreshQueued = true;
+			return;
+		}
+
+		this.refreshRunning = true;
+		try {
+			const editorInfo = this.view.state.field(editorInfoField, false);
+			if (editorInfo instanceof MarkdownView) {
+				await this.plugin.handleAddHeaderNumber(editorInfo);
+				if (this.plugin.settings.isAutoDetectHeaderLevel) {
+					this.plugin.handleShowStateBarChange();
+				}
+			}
+		} finally {
+			this.refreshRunning = false;
+			if (this.refreshQueued && !this.destroyed) {
+				this.refreshQueued = false;
+				if (
+					!this.tracker.hasSelectionOnDirtyLine(
+						this.view.state.doc,
+						this.view.state.selection
+					)
+				) {
+					this.scheduleRefresh();
+				}
+			}
+		}
 	}
 }

--- a/src/editor/heading-change.ts
+++ b/src/editor/heading-change.ts
@@ -1,0 +1,84 @@
+import type { ChangeDesc, EditorSelection, Text, Transaction } from "@codemirror/state";
+
+import { isHeader } from "../core";
+
+export const HEADER_ENHANCER_USER_EVENT = "HeaderEnhancer.changeAutoNumbering";
+
+export function isTrackedDocumentChange(transaction: Transaction): boolean {
+	return transaction.docChanged &&
+		!transaction.isUserEvent(HEADER_ENHANCER_USER_EVENT);
+}
+
+export class HeadingChangeTracker {
+	private dirtyLinePositions = new Set<number>();
+
+	applyChanges(startDoc: Text, doc: Text, changes: ChangeDesc): void {
+		this.dirtyLinePositions = new Set(
+			Array.from(this.dirtyLinePositions, (position) => changes.mapPos(position, 1))
+		);
+
+		changes.iterChangedRanges((fromA, toA, fromB, toB) => {
+			this.addHeadingLines(startDoc, fromA, toA, (position) =>
+				changes.mapPos(position, 1)
+			);
+			this.addHeadingLines(doc, fromB, toB, (position) => position);
+		});
+	}
+
+	clear(): void {
+		this.dirtyLinePositions.clear();
+	}
+
+	consume(): boolean {
+		if (this.dirtyLinePositions.size === 0) {
+			return false;
+		}
+
+		this.clear();
+		return true;
+	}
+
+	hasSelectionOnDirtyLine(doc: Text, selection: EditorSelection): boolean {
+		return this.dirtyLinePositions.size > 0 &&
+			this.selectionTouchesDirtyLine(doc, selection);
+	}
+
+	consumeIfSelectionLeft(doc: Text, selection: EditorSelection): boolean {
+		if (this.dirtyLinePositions.size === 0 || this.hasSelectionOnDirtyLine(doc, selection)) {
+			return false;
+		}
+
+		return this.consume();
+	}
+
+	private addHeadingLines(
+		doc: Text,
+		from: number,
+		to: number,
+		mapPosition: (position: number) => number
+	): void {
+		const startLine = doc.lineAt(Math.min(from, doc.length)).number;
+		const endLine = doc.lineAt(Math.min(to, doc.length)).number;
+
+		for (let lineNumber = startLine; lineNumber <= endLine; lineNumber++) {
+			const line = doc.line(lineNumber);
+			if (isHeader(line.text)) {
+				this.dirtyLinePositions.add(mapPosition(line.from));
+			}
+		}
+	}
+
+	private selectionTouchesDirtyLine(doc: Text, selection: EditorSelection): boolean {
+		const dirtyLineNumbers = new Set(
+			Array.from(this.dirtyLinePositions, (position) => doc.lineAt(position).number)
+		);
+
+		return selection.ranges.some((range) => {
+			const fromLine = doc.lineAt(range.from).number;
+			const toLine = doc.lineAt(range.to).number;
+			return Array.from(dirtyLineNumbers).some(
+				(lineNumber) => lineNumber >= fromLine && lineNumber <= toLine
+			);
+		});
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { Editor, MarkdownView, Notice, Plugin, TFile } from "obsidian";
+import type { EditorChange } from "obsidian";
 
 import {
 	getHeaderLevel,
@@ -22,6 +23,7 @@ import { getAutoNumberingConfig } from "./config";
 import { I18n } from "./i18n";
 import { BacklinkManager } from "./backlinks";
 import { EditorHandlers } from "./editor/editor-handlers";
+import { HEADER_ENHANCER_USER_EVENT } from "./editor/heading-change";
 import { StyleManager } from "./styles/style-manager";
 
 export default class HeaderEnhancerPlugin extends Plugin {
@@ -87,6 +89,7 @@ export default class HeaderEnhancerPlugin extends Plugin {
 		// Register editor extensions
 		const keyHandlers = this.editorHandlers.registerKeyHandlers();
 		keyHandlers.forEach(handler => this.registerEditorExtension(handler));
+		this.registerEditorExtension(this.editorHandlers.registerHeadingRefreshHandler());
 
 		// Register event listeners for document switching
 		this.registerEvent(
@@ -498,6 +501,7 @@ export default class HeaderEnhancerPlugin extends Plugin {
 		// Get current file for backlink processing
 		const currentFile = view.file;
 		const headerChanges: Array<{lineIndex: number, oldText: string, newText: string, originalHeading: string}> = [];
+		const editorChanges: EditorChange[] = [];
 
 		if (config.state) {
 			let insertNumber: number[] = [Number(config.startNumber) - 1];
@@ -568,10 +572,20 @@ export default class HeaderEnhancerPlugin extends Plugin {
 							originalHeading: originalHeading
 						});
 						
-						// Apply changes
-						editor.setLine(i, newLine);
+						editorChanges.push({
+							from: { line: i, ch: 0 },
+							to: { line: i, ch: line.length },
+							text: newLine,
+						});
 					}
 				}
+			}
+
+			if (editorChanges.length > 0) {
+				editor.transaction(
+					{ changes: editorChanges },
+					HEADER_ENHANCER_USER_EVENT
+				);
 			}
 
 			// Handle backlink updates
@@ -661,6 +675,7 @@ export default class HeaderEnhancerPlugin extends Plugin {
 		// Get current file for backlink processing
 		const currentFile = view.file;
 		const headerChanges: Array<{lineIndex: number, oldText: string, newText: string, originalHeading: string}> = [];
+		const editorChanges: EditorChange[] = [];
 
 		// Always attempt to remove numbering regardless of current state
 		// This allows cleanup even when auto numbering is disabled
@@ -694,9 +709,20 @@ export default class HeaderEnhancerPlugin extends Plugin {
 						});
 					}
 					
-					editor.setLine(i, newLine);
+					editorChanges.push({
+						from: { line: i, ch: 0 },
+						to: { line: i, ch: line.length },
+						text: newLine,
+					});
 				}
 			}
+		}
+
+		if (editorChanges.length > 0) {
+			editor.transaction(
+				{ changes: editorChanges },
+				HEADER_ENHANCER_USER_EVENT
+			);
 		}
 		
 		// Handle backlink updates - from numbered format back to original format

--- a/tests/heading-change.test.mjs
+++ b/tests/heading-change.test.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { EditorSelection, EditorState } from "@codemirror/state";
+import { build } from "esbuild";
+
+const result = await build({
+	entryPoints: ["src/editor/heading-change.ts"],
+	bundle: true,
+	format: "esm",
+	platform: "node",
+	write: false,
+	logLevel: "silent",
+});
+const source = result.outputFiles[0].text;
+const headingChange = await import(
+	`data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+);
+
+function applyChange(doc, changes, userEvent = "input.type") {
+	const state = EditorState.create({ doc });
+	const transaction = state.update({ changes, userEvent });
+	return { state, transaction };
+}
+
+test("tracks a changed heading until the cursor leaves its line", () => {
+	const tracker = new headingChange.HeadingChangeTracker();
+	const { state, transaction } = applyChange(
+		"# 1 Heading\nParagraph",
+		{ from: 11, to: 11, insert: " updated" }
+	);
+
+	tracker.applyChanges(state.doc, transaction.state.doc, transaction.changes);
+	assert.equal(
+		tracker.hasSelectionOnDirtyLine(
+			transaction.state.doc,
+			EditorSelection.single(19)
+		),
+		true
+	);
+	assert.equal(
+		tracker.consumeIfSelectionLeft(
+			transaction.state.doc,
+			EditorSelection.single(19)
+		),
+		false
+	);
+	assert.equal(
+		tracker.consumeIfSelectionLeft(
+			transaction.state.doc,
+			EditorSelection.single(transaction.state.doc.length)
+		),
+		true
+	);
+});
+
+test("tracks lines changed into or out of headings", () => {
+	for (const [doc, changes] of [
+		["Paragraph\nNext", { from: 0, to: 0, insert: "# " }],
+		["# Heading\nNext", { from: 0, to: 2, insert: "" }],
+	]) {
+		const tracker = new headingChange.HeadingChangeTracker();
+		const { state, transaction } = applyChange(doc, changes);
+		tracker.applyChanges(state.doc, transaction.state.doc, transaction.changes);
+
+		assert.equal(
+			tracker.consumeIfSelectionLeft(
+				transaction.state.doc,
+				EditorSelection.single(transaction.state.doc.length)
+			),
+			true
+		);
+	}
+});
+
+test("does not track ordinary paragraph edits", () => {
+	const tracker = new headingChange.HeadingChangeTracker();
+	const { state, transaction } = applyChange(
+		"Paragraph\nNext",
+		{ from: 9, to: 9, insert: " updated" }
+	);
+
+	tracker.applyChanges(state.doc, transaction.state.doc, transaction.changes);
+	assert.equal(
+		tracker.consumeIfSelectionLeft(
+			transaction.state.doc,
+			EditorSelection.single(transaction.state.doc.length)
+		),
+		false
+	);
+});
+
+test("consumes a changed heading when the editor loses focus", () => {
+	const tracker = new headingChange.HeadingChangeTracker();
+	const { state, transaction } = applyChange(
+		"# Heading\nParagraph",
+		{ from: 9, insert: " updated" }
+	);
+
+	tracker.applyChanges(state.doc, transaction.state.doc, transaction.changes);
+	assert.equal(tracker.consume(), true);
+	assert.equal(tracker.consume(), false);
+});
+
+test("tracks document edits and ignores plugin numbering transactions", () => {
+	const state = EditorState.create({ doc: "# Heading" });
+	const userTransaction = state.update({
+		changes: { from: 9, insert: " updated" },
+		userEvent: "input.type",
+	});
+	const programmaticTransaction = state.update({
+		changes: { from: 9, insert: " updated" },
+	});
+	const pluginTransaction = state.update({
+		changes: { from: 2, insert: "1 " },
+		userEvent: headingChange.HEADER_ENHANCER_USER_EVENT,
+	});
+
+	assert.equal(headingChange.isTrackedDocumentChange(userTransaction), true);
+	assert.equal(headingChange.isTrackedDocumentChange(programmaticTransaction), true);
+	assert.equal(headingChange.isTrackedDocumentChange(pluginTransaction), false);
+	assert.equal(
+		headingChange.isTrackedDocumentChange(state.update({ selection: { anchor: 1 } })),
+		false
+	);
+});
+
+test("waits for every cursor to leave modified heading lines", () => {
+	const tracker = new headingChange.HeadingChangeTracker();
+	const state = EditorState.create({ doc: "# First\n# Second\nParagraph" });
+	const transaction = state.update({
+		changes: [
+			{ from: 7, insert: " updated" },
+			{ from: 16, insert: " updated" },
+		],
+		userEvent: "input.type",
+	});
+
+	tracker.applyChanges(state.doc, transaction.state.doc, transaction.changes);
+	assert.equal(
+		tracker.consumeIfSelectionLeft(
+			transaction.state.doc,
+			EditorSelection.create([
+				EditorSelection.cursor(5),
+				EditorSelection.cursor(25),
+			])
+		),
+		false
+	);
+	assert.equal(
+		tracker.consumeIfSelectionLeft(
+			transaction.state.doc,
+			EditorSelection.single(transaction.state.doc.length)
+		),
+		true
+	);
+});
+
+test("keeps tracking a changed heading when earlier lines shift", () => {
+	const tracker = new headingChange.HeadingChangeTracker();
+	const initialState = EditorState.create({ doc: "# Heading\nParagraph" });
+	const headingEdit = initialState.update({
+		changes: { from: 9, insert: " updated" },
+		userEvent: "input.type",
+	});
+	tracker.applyChanges(
+		initialState.doc,
+		headingEdit.state.doc,
+		headingEdit.changes
+	);
+
+	const lineInsert = headingEdit.state.update({
+		changes: { from: 0, insert: "Intro\n" },
+		userEvent: "input.type",
+	});
+	tracker.applyChanges(
+		headingEdit.state.doc,
+		lineInsert.state.doc,
+		lineInsert.changes
+	);
+
+	assert.equal(
+		tracker.hasSelectionOnDirtyLine(
+			lineInsert.state.doc,
+			EditorSelection.single(12)
+		),
+		true
+	);
+	assert.equal(
+		tracker.consumeIfSelectionLeft(
+			lineInsert.state.doc,
+			EditorSelection.single(lineInsert.state.doc.length)
+		),
+		true
+	);
+});


### PR DESCRIPTION
## What changed
- track edits that affect heading lines and refresh numbering only after every cursor leaves those lines
- debounce refreshes by 200ms, serialize async work, and pause pending refreshes while another heading is being edited
- map each CodeMirror editor to its own Markdown view so split panes refresh the correct document
- apply numbering changes in one marked transaction and ignore those plugin-generated changes to prevent refresh loops
- update the English and Chinese usage documentation

## Performance
- ordinary paragraph edits do not schedule a document scan
- multiple heading edits are merged into one refresh
- backlink updates run only when numbering actually changes
- plugin-generated numbering transactions are ignored by the heading tracker

## Verification
- `npm test` (13 tests)
- `npm run build`
- `git diff --check`

`npx tsc --noEmit` still reports the seven existing type errors on `main`; this change introduces no new TypeScript errors.

Closes #50